### PR TITLE
Switched from kernel 4.7.2 to 3.14.79 (after backporting overlayfs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # platform-cuboxi
 Platform files for SolidRun Cuboxi/ Hummingboard
 
-Kernel Sources: http://www.kernel.org, Version 4.7.2
+Kernel Sources: Mainline (unused as of 20170129) http://www.kernel.org, Version 4.7.2  
+		Legacy (used as of 20170129) https://github.com/SolidRun/linux-fslc  
 
 This repo contains all platform-specific files, used by the Volumio Builder to create **cubox-i** and **hummingboard** images:
 
@@ -22,5 +23,10 @@ This repo contains all platform-specific files, used by the Volumio Builder to c
 - 20160913: Added ALSA aliases            
 - 20160926: Added Broadcom WLAN drivers
 - 20161127: Added /lib/firmware/brcm/brcmfmac4329-sdio.txt and /lib/firmware/brcm/brcmfmac4329-sdio.txt  
-- 20170122: Added Kernel option 'cfg80211 wireless extensions compatibility'
+- 20170122: Added Kernel option 'cfg80211 wireless extensions compatibility'  
+- 20170129: ===== Reversed to Legacy Kernel 3.14.79  
+
+**Platform files with kernel version 4.7.2**
+- 20170129: Changed to Kernel 3.14.79 after backporting overlayfs with a modified patch-set  
+
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # platform-cuboxi
 Platform files for SolidRun Cuboxi/ Hummingboard
 
-Kernel Sources: Mainline (unused as of 20170129) http://www.kernel.org, Version 4.7.2  
-		Legacy (used as of 20170129) https://github.com/SolidRun/linux-fslc  
+Kernel Sources:  
+Mainline (unused as of 20170129) http://www.kernel.org, version 4.7.2  
+Legacy (used as of 20170129) https://github.com/SolidRun/linux-fslc, version 3.14.79  
 
 This repo contains all platform-specific files, used by the Volumio Builder to create **cubox-i** and **hummingboard** images:
 
@@ -26,7 +27,7 @@ This repo contains all platform-specific files, used by the Volumio Builder to c
 - 20170122: Added Kernel option 'cfg80211 wireless extensions compatibility'  
 - 20170129: ===== Reversed to Legacy Kernel 3.14.79  
 
-**Platform files with kernel version 4.7.2**
-- 20170129: Changed to Kernel 3.14.79 after backporting overlayfs with a modified patch-set  
+**Platform files with kernel version 3.14.79**
+- 20170129: Changed from Kernel 4.7.2 to 3.14.79 after backporting overlayfs with a modified patch-set  
 
 


### PR DESCRIPTION
This is a short term solution, volumio/ cubox with 4.7.2 works, but is awfully slow on library updates.
I believe there are issues with networking.
A long term solution could be the newest mainline stable kernel (4.7.2 is already outdated). 
Needs to be investigated.
-- Gé --
 